### PR TITLE
Added cookie consent

### DIFF
--- a/src/Admin/Locales/pt-BR.po
+++ b/src/Admin/Locales/pt-BR.po
@@ -124,6 +124,9 @@ msgstr "Explícito"
 msgid "External"
 msgstr "Externo"
 
+msgid "I understand"
+msgstr "Entendi"
+
 msgid "Implicit"
 msgstr "Implícito"
 
@@ -297,6 +300,9 @@ msgstr "A permissão foi modificada. Verifique os dados e tente novamente"
 
 msgid "The type is required"
 msgstr "O tipo é obrigatório"
+
+msgid "This site stores data like cookies to enable required functionality"
+msgstr "Este site armazena dados como cookies para habilitar funcionalidades obrigatórias"
 
 msgid "Toggle client secret visibility"
 msgstr "Alternar visibilidade do client secret"

--- a/src/Admin/Views/Shared/_CookieConsent.cshtml
+++ b/src/Admin/Views/Shared/_CookieConsent.cshtml
@@ -1,0 +1,8 @@
+@inject IViewLocalizer localizer
+
+<script>
+    window.cookieconsent.show({
+        message: '@localizer["This site stores data like cookies to enable required functionality"]',
+        dismiss: '@localizer["I understand"]'
+    });
+</script>

--- a/src/Admin/Views/Shared/_Layout.cshtml
+++ b/src/Admin/Views/Shared/_Layout.cshtml
@@ -16,6 +16,7 @@
     <link rel="stylesheet" href="@assets.Url("bootstrap/bootstrap.min.css")" />
     <link rel="stylesheet" href="@assets.Url("bootstrap-icons/bootstrap-icons.min.css")" />
     <link rel="stylesheet" href="@assets.Url("impromptu/impromptu.min.css")" />
+    <link rel="stylesheet" href="@assets.Url("cookieconsent/cookieconsent.min.css")" />
     <link rel="stylesheet" href="~/lib/tagify/tagify.min.css" />
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
 </head>
@@ -47,9 +48,12 @@
     <script src="@assets.Url("bootstrap/bootstrap.bundle.min.js")"></script>
     <script src="@assets.Url("jquery-validation/jquery.validate.min.js")"></script>
     <script src="@assets.Url("jquery-validation-unobtrusive/jquery.validate.unobtrusive.min.js")"></script>
+    <script src="@assets.Url("cookieconsent/cookieconsent.min.js")"></script>
     <script src="~/lib/tagify/tagify.min.js"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>
+    <script src="~/js/cookieconsent.js" asp-append-version="true"></script>
 
+    <partial name="./_CookieConsent" />
     @await RenderSectionAsync("Scripts", required: false)
 </body>
 </html>

--- a/src/Admin/wwwroot/js/cookieconsent.js
+++ b/src/Admin/wwwroot/js/cookieconsent.js
@@ -1,0 +1,23 @@
+
+window.cookieconsent.show = function(options) {
+  const message = options.message;
+  const dismiss = options.dismiss;
+
+  window.cookieconsent.initialise({
+    palette: {
+      popup: {
+        background: '#252e39',
+      },
+      button: {
+        background: '#14a7d0',
+      },
+    },
+    theme: 'classic',
+    position: 'bottom-right',
+    showLink: false,
+    content: {
+      message: message,
+      dismiss: dismiss,
+    },
+  });
+}

--- a/src/Server/Locales/en.po
+++ b/src/Server/Locales/en.po
@@ -1,2 +1,0 @@
-msgid "Log in"
-msgstr ""

--- a/src/Server/Locales/pt-BR.po
+++ b/src/Server/Locales/pt-BR.po
@@ -1,5 +1,11 @@
+msgid "I understand"
+msgstr "Entendi"
+
 msgid "Invalid client id"
 msgstr "Client id inválido"
 
 msgid "Invalid user"
 msgstr "Usuário inválido"
+
+msgid "This site stores data like cookies to enable required functionality"
+msgstr "Este site armazena dados como cookies para habilitar funcionalidades obrigatórias"

--- a/src/Server/Views/Shared/_CookieConsent.cshtml
+++ b/src/Server/Views/Shared/_CookieConsent.cshtml
@@ -1,0 +1,8 @@
+@inject IViewLocalizer localizer
+
+<script>
+    window.cookieconsent.show({
+        message: '@localizer["This site stores data like cookies to enable required functionality"]',
+        dismiss: '@localizer["I understand"]'
+    });
+</script>

--- a/src/Server/Views/Shared/_Layout.cshtml
+++ b/src/Server/Views/Shared/_Layout.cshtml
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@ViewData["Title"] - Server</title>
     <link rel="stylesheet" href="@assets.Url("bootstrap/bootstrap.min.css")" />
+    <link rel="stylesheet" href="@assets.Url("cookieconsent/cookieconsent.min.css")" />
     <link rel="stylesheet" href="~/css/site.css" />
 </head>
 <body>
@@ -37,7 +38,11 @@
     </footer>
     <script src="@assets.Url("jquery/jquery.min.js")"></script>
     <script src="@assets.Url("bootstrap/bootstrap.bundle.min.js")"></script>
+    <script src="@assets.Url("cookieconsent/cookieconsent.min.js")"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>
+    <script src="~/js/cookieconsent.js" asp-append-version="true"></script>
+
+    <partial name="./_CookieConsent" />
     @await RenderSectionAsync("Scripts", required: false)
 </body>
 </html>

--- a/src/Server/Views/_ViewImports.cshtml
+++ b/src/Server/Views/_ViewImports.cshtml
@@ -1,2 +1,3 @@
-﻿@using Nocturne.Auth.Core.Web
+﻿@using Microsoft.AspNetCore.Mvc.Localization
+@using Nocturne.Auth.Core.Web
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/src/Server/appsettings.json
+++ b/src/Server/appsettings.json
@@ -8,6 +8,9 @@
       "RequireConfirmedAccount": true
     }
   },
+  "Localization": {
+    "DefaultCulture": "pt-BR"
+  },
   "Email": {
     "SenderName": "",
     "SenderEmail": "",

--- a/src/Server/wwwroot/js/cookieconsent.js
+++ b/src/Server/wwwroot/js/cookieconsent.js
@@ -1,0 +1,23 @@
+
+window.cookieconsent.show = function(options) {
+  const message = options.message;
+  const dismiss = options.dismiss;
+
+  window.cookieconsent.initialise({
+    palette: {
+      popup: {
+        background: '#252e39',
+      },
+      button: {
+        background: '#14a7d0',
+      },
+    },
+    theme: 'classic',
+    position: 'bottom-right',
+    showLink: false,
+    content: {
+      message: message,
+      dismiss: dismiss,
+    },
+  });
+}


### PR DESCRIPTION
Added cookie consent about the cookies used by the applications to store required data like authentication, as described in #4.

Both applications share the same logic, but it is currently duplicated.