### PR TITLE
Fixed pt-BR translation of welcome in Admin homepage

### DIFF
--- a/src/Admin/Locales/pt-BR.po
+++ b/src/Admin/Locales/pt-BR.po
@@ -371,7 +371,7 @@ msgid "User not found"
 msgstr "Usuário não encontrado"
 
 msgid "Welcome"
-msgstr "Bem-vindo"
+msgstr "Boas-vindas"
 
 msgid "with PKCE"
 msgstr "com PKCE"


### PR DESCRIPTION
Fixes #44 by changing the `pt-BR` translation of `Welcome` to `Boas-vindas`.