### PR TITLE
Automatically generate Client Id and Client Secret on Admin initialization

### DIFF
--- a/src/Admin/appsettings.json
+++ b/src/Admin/appsettings.json
@@ -7,8 +7,8 @@
   },
   "Authorization": {
     "Authority": "https://localhost:61767/",
-    "ClientId": "37ccb205-b374-4739-b974-fa9b8581d0ea",
-    "ClientSecret": "028ff01a-1c8c-443d-8174-464d34f06c41",
+    "ClientId": "",
+    "ClientSecret": "",
     "RequireHttps": false,
     "Scopes": ["email", "profile", "roles", "offline_access"]
   },

--- a/src/Admin/initialize.json
+++ b/src/Admin/initialize.json
@@ -18,8 +18,6 @@
       }
     ],
     "AdminApplication": {
-      "ClientId": "37ccb205-b374-4739-b974-fa9b8581d0ea",
-      "ClientSecret": "028ff01a-1c8c-443d-8174-464d34f06c41",
       "ConsentType": "explicit",
       "DisplayName": "Authorization Server (Admin)",
       "Type": "confidential",


### PR DESCRIPTION
Before we can tackle a better setup environment, this automates the Admin application's Client Id and Client Secret generation on initialization, to make it more secure. The values are logged after completing the `dotnet run --init` command (and lost if the command line is closed).