### PR TITLE
Fixes the search of local certificates for data protection encryption

### DIFF
--- a/src/Configuration/Services/DataProtectionServices.cs
+++ b/src/Configuration/Services/DataProtectionServices.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Nocturne.Auth.Configuration.Models;
 using Nocturne.Auth.Core.Services.DataProtection;
+using Nocturne.Auth.Core.Shared.Helpers;
 
 namespace Nocturne.Auth.Configuration.Services
 {
@@ -32,7 +33,10 @@ namespace Nocturne.Auth.Configuration.Services
 
             if (string.IsNullOrWhiteSpace(options.EncryptionCertificateThumbprint) is false)
             {
-                builder.ProtectKeysWithCertificate(options.EncryptionCertificateThumbprint);
+                var certificate = X509CertificateLocator.FindByThumbprint(
+                    options.EncryptionCertificateThumbprint);
+
+                builder.ProtectKeysWithCertificate(certificate);
             }
 
             return builder;

--- a/src/Core/Shared/Helpers/X509CertificateLocator.cs
+++ b/src/Core/Shared/Helpers/X509CertificateLocator.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Leandro Silva Luz do Carmo
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+using System;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Nocturne.Auth.Core.Shared.Helpers
+{
+    public static class X509CertificateLocator
+    {
+        public static X509Certificate2 FindByThumbprint(string thumbprint)
+        {
+            return Find(
+                StoreName.My,
+                StoreLocation.LocalMachine,
+                X509FindType.FindByThumbprint,
+                thumbprint);
+        }
+
+        private static X509Certificate2 Find(
+            StoreName storeName,
+            StoreLocation storeLocation,
+            X509FindType findType,
+            object findValue)
+        {
+            const bool allowSelfSignedCertificates = true;
+
+            var store = new X509Store(
+                storeName,
+                storeLocation,
+                OpenFlags.ReadOnly);
+
+            var foundCertificates = store.Certificates.Find(
+                findType,
+                findValue,
+                validOnly: !allowSelfSignedCertificates);
+
+            if (foundCertificates.Count == 0)
+            {
+                throw new InvalidOperationException(
+                    $"No certificate using the specified search criteria");
+            }
+
+            return foundCertificates[0];
+        }
+    }
+}

--- a/src/Core/Shared/Helpers/X509CertificateLocator.cs
+++ b/src/Core/Shared/Helpers/X509CertificateLocator.cs
@@ -38,7 +38,7 @@ namespace Nocturne.Auth.Core.Shared.Helpers
             if (foundCertificates.Count == 0)
             {
                 throw new InvalidOperationException(
-                    $"No certificate using the specified search criteria");
+                    $"No certificate found using the specified search criteria");
             }
 
             return foundCertificates[0];


### PR DESCRIPTION
By default the certificate find method from the `X509Store` only searches for valid certificates, meaning that local self-signed certificates could not be used by the DataProtection. This PR fixes the problem by allowing the use of not trusted certificates from the local machine.