### PR TITLE
Fixed localization of create/edit application form's title

### DIFF
--- a/src/Admin/Views/Applications/Create.cshtml
+++ b/src/Admin/Views/Applications/Create.cshtml
@@ -1,7 +1,8 @@
 @model CreateApplicationCommand
+@inject IViewLocalizer Localizer;
 
 @{
-    ViewData[KnownViewData.Title] = "New application";
+    ViewData[KnownViewData.Title] = Localizer["New application"];
     ViewData[KnownViewData.PageGroup] = PageGroups.Applications;
     ViewData[KnownViewData.ReturnTitle] = "Applications";
     ViewData[KnownViewData.ReturnUrl] = Url.RouteUrl(RouteNames.ApplicationsHome);

--- a/src/Admin/Views/Applications/Edit.cshtml
+++ b/src/Admin/Views/Applications/Edit.cshtml
@@ -1,7 +1,8 @@
 @model EditApplicationCommand
+@inject IViewLocalizer Localizer;
 
 @{
-    ViewData[KnownViewData.Title] = "Edit application";
+    ViewData[KnownViewData.Title] = Localizer["Edit application"];
     ViewData[KnownViewData.PageGroup] = PageGroups.Applications;
     ViewData[KnownViewData.ReturnTitle] = "Application details";
     ViewData[KnownViewData.ReturnUrl] = Url.RouteUrl(RouteNames.ApplicationsView, new { Model.Id });

--- a/src/Admin/Views/Applications/_Form.cshtml
+++ b/src/Admin/Views/Applications/_Form.cshtml
@@ -1,9 +1,9 @@
 @using static OpenIddict.Abstractions.OpenIddictConstants;
 @model ManageApplicationCommand
-@inject IViewLocalizer localizer
+@inject IViewLocalizer localizer;
 
 @{
-    var title = localizer[(string)ViewData[KnownViewData.Title]];
+    var title = ViewData[KnownViewData.Title];
     var returnUrl = ViewData[KnownViewData.ReturnUrl];
     var returnTitle = localizer[(string)ViewData[KnownViewData.ReturnTitle]];
 }


### PR DESCRIPTION
The create/edit application form's title was not being localized, as the localization was being done after the `ViewData[Title]` was set, making the layout take the unlocalized value.